### PR TITLE
Add support for `textdagger` macro

### DIFF
--- a/src/main/scala/com/github/tomtung/latex2unicode/helper/Escape.scala
+++ b/src/main/scala/com/github/tomtung/latex2unicode/helper/Escape.scala
@@ -296,6 +296,7 @@ object Escape {
     "\\daleth" -> "ד",
     "\\dag" -> "†",
     "\\dagger" -> "†",
+    "\\textdagger" -> "†",
     "\\curvearrowright" -> "↷",
     "\\curvearrowleft" -> "↶",
     "\\curlywedge" -> "⋏",


### PR DESCRIPTION
A user of JabRef reported that the `\textdagger` is not yet supported by the unicode conversion https://github.com/JabRef/jabref/issues/2757. This PR adds this command. I just copied the `\dagger` symbol.