### PR TITLE
Add Automatic-Module-Name for Java 9 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,3 +43,7 @@ pomExtra := (
         <url>http://tomtung.com</url>
       </developer>
     </developers>)
+
+packageOptions in (Compile, packageBin) += Package.ManifestAttributes(
+  "Automatic-Module-Name" -> "com.github.tomtung.latex2unicode"
+)


### PR DESCRIPTION
This adds an [`Automatic-Module-Name`](http://branchandbound.net/blog/java/2017/12/automatic-module-name/) to the JAR manifests, allowing the library to be used on the Java 9 module path.

If the library was used before on the Java 9 module path, the module name was derived from the filename of the JAR at runtime to `latex2unicode.2.12`, which is not a valid Java identifier.

Latex2unicode is compatible with Java 9 when the dependency on fastparse was updated to a version where https://github.com/lihaoyi/fastparse/pull/185 is included.

Closes #10 