### PR TITLE
Fix #9.

### DIFF
--- a/src/test/scala/com/github/tomtung/latex2unicode/Latex2UnicodeTest.scala
+++ b/src/test/scala/com/github/tomtung/latex2unicode/Latex2UnicodeTest.scala
@@ -122,6 +122,7 @@ class LaTeX2UnicodeTest extends FunSuite {
   test("\\sqrt") {
     LaTeX2Unicode.convert("\\sqrt{}") shouldBe "√"
     LaTeX2Unicode.convert("\\sqrt x") shouldBe "√x̅"
+    LaTeX2Unicode.convert("\\sqrt \\alpha") shouldBe "√α̅"
     LaTeX2Unicode.convert("\\sqrt\nx") shouldBe "√x̅"
     LaTeX2Unicode.convert("\\sqrt[]x") shouldBe "√x̅"
     LaTeX2Unicode.convert("\\sqrt[]\nx") shouldBe "√x̅"
@@ -164,7 +165,11 @@ class LaTeX2UnicodeTest extends FunSuite {
   }
 
   test("Unknown commands") {
-    LaTeX2Unicode.convert("""\this \is \alpha test""") shouldBe """\this \is α test"""
+    LaTeX2Unicode.convert("\\this \\is \\alpha test") shouldBe "\\this \\is α test"
+    LaTeX2Unicode.convert("\\unknown command") shouldBe "\\unknown command"
+    LaTeX2Unicode.convert("\\unknown{} empty params") shouldBe "\\unknown{} empty params"
+    LaTeX2Unicode.convert("\\unknown{cmd}") shouldBe "\\unknown{cmd}"
+    LaTeX2Unicode.convert("\\unknown{1}{2}") shouldBe "\\unknown{1}{2}"
+    LaTeX2Unicode.convert("\\unknown{1}{2}{3}") shouldBe "\\unknown{1}{2}{3}"
   }
-
 }


### PR DESCRIPTION
With this PR, arguments for unknown commands are preserved. This fixes #9.
Now inputs such as `\unknown{param}` yield the output `\unknown{param}` where previously it produced `\unknownparam`. The implementation treats all blocks that directly follow a unknown command as arguments to this command (e.g. `\unknown{param}{param}` but `\unknown{param} {not a param}` because of the space). This leads to false positives if in reality the unknown command excepts less arguments. For example, if `\$` is not known to latex2unicode, then `\${abc}` would still produce `\${abc}` although in this case it would probably better to produce `\$ abc`. I went for this implementation due to the following reasons:
- I believe, strings of the format `\command{block}{block}` in most cases mean that the command is invoked with two arguments. In latex, you almost never need to use brackets to group things. The only common exception are style commands like `{\bf text}` - but since `\bf` and co are [deprecated](https://tex.stackexchange.com/questions/41681/correct-way-to-bold-italicize-text) and are supported by latex2unicode, this shouldn't be a big problem.
- The output from false positives is easier to understand (the previous output `\unknownparam` leads to confusion, while `\unknown{param}` still lets the user infer the original meaning).
