### PR TITLE
Fix minus to minus hypen again

### DIFF
--- a/src/main/scala/com/github/tomtung/latex2unicode/helper/Escape.scala
+++ b/src/main/scala/com/github/tomtung/latex2unicode/helper/Escape.scala
@@ -18,7 +18,7 @@ object Escape {
     "\\quad" -> " ",
     "\\qquad" -> " ",
     """\\""" -> "\n",
-    "-" -> "\u2212",
+    "-" -> "-",
     "--" -> "\u2013",
     "---" -> "\u2014",
     "\\colon" -> ":",
@@ -38,6 +38,7 @@ object Escape {
     "\\textregistered" -> "®",
     "\\textquestiondown" -> "¿",
     "\\textvisiblespace" -> "␣",
+    "\\textminus" -> "\u2212",
 
     // Greek alphabet
     "\\alpha" -> "α",

--- a/src/test/scala/com/github/tomtung/latex2unicode/Latex2UnicodeTest.scala
+++ b/src/test/scala/com/github/tomtung/latex2unicode/Latex2UnicodeTest.scala
@@ -41,7 +41,7 @@ class LaTeX2UnicodeTest extends AnyFunSuite {
   test("Dashes") {
     LaTeX2Unicode.convert(
       "5-1 is between 1--10---obviously. ----anonymous"
-    ) shouldBe "5−1 is between 1–10—obviously. ----anonymous"
+    ) shouldBe "5-1 is between 1-10—obviously. ----anonymous"
   }
 
   test("ams arrows") {

--- a/src/test/scala/com/github/tomtung/latex2unicode/Latex2UnicodeTest.scala
+++ b/src/test/scala/com/github/tomtung/latex2unicode/Latex2UnicodeTest.scala
@@ -41,7 +41,7 @@ class LaTeX2UnicodeTest extends AnyFunSuite {
   test("Dashes") {
     LaTeX2Unicode.convert(
       "5-1 is between 1--10---obviously. ----anonymous"
-    ) shouldBe "5-1 is between 1-10—obviously. ----anonymous"
+    ) shouldBe "5-1 is between 1–10—obviously. ----anonymous"
   }
 
   test("ams arrows") {


### PR DESCRIPTION
As noted in  https://github.com/tomtung/latex2unicode/pull/15#issuecomment-1095374157
Replace - with hypen minus and \textminus with \u2212